### PR TITLE
Build warning: Ignoring deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <jenkins.version>2.289.1</jenkins.version>
-        <java.level>8</java.level>
     </properties>
     <name>commons-lang3 v3.x Jenkins Api Plugin</name>
     <description>Jenkins Api Plugin to provide org.apache.commons:commons-lang3:${commons-lang3.version}.


### PR DESCRIPTION
### Steps to reproduce

Run `mvn clean verify -DskipTests` as of HEAD (at the time of current writing, commit afa4de2).

### Expected Results

The build completes with no warnings.

### Actual Results

The build completes with the following warning:

```
[…]
[INFO] --- maven-hpi-plugin:3.27:validate (default-validate) @ commons-lang3-api ---
[WARNING] Ignoring deprecated java.level property. This property should be removed from your plugin's POM. In the future this warning will be changed to an error and will break the build.
[…]
```

### Evaluation

Commit bb7726b was integrated without reading release notes: jenkinsci/plugin-pom#522. As the warning states, this property now has no effect and should be removed from the plugin's POM.

### Solution

Remove the unused property from the plugin's POM.

### Testing done

Reproduced the problem as described above. Before this PR, the problem could be reproduced as described above. After this PR, the problem can no longer be reproduced.

CC @nhojpatrick