### PR TITLE
Use `project.artifactId` where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>commons-lang3 v3.x Jenkins Api Plugin</name>
     <description>Jenkins Api Plugin to provide org.apache.commons:commons-lang3:${commons-lang3.version}.
         Will break usage upon jars being provided by core jenkins.</description>
-    <url>https://github.com/jenkinsci/commons-lang3-api-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
Consistent with [the archetype](https://github.com/jenkinsci/archetypes/blob/a7c4ecaa53c7971f8ae2cababf3a25911f755351/empty-plugin/src/main/resources/archetype-resources/pom.xml#L15=).

CC @nhojpatrick

