### PR TITLE
Bump core to 2.289.3 to remove implied sshd dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <properties>
         <commons-lang3.version>3.12.0</commons-lang3.version>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
     </properties>
     <name>commons-lang3 v3.x Jenkins Api Plugin</name>
     <description>Jenkins Api Plugin to provide org.apache.commons:commons-lang3:${commons-lang3.version}.


### PR DESCRIPTION
Should fix https://github.com/jenkinsci/commons-lang3-api-plugin/issues/18

As per https://www.jenkins.io/doc/upgrade-guide/2.289/#sshd-module-unbundling.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue