### PR TITLE
Enable CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,15 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 commons-lang3-api Plugin
 ===================
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/commons-lang3-api-plugin/job/main/badge/icon)](https://ci.jenkins.io/job/Plugins/job/commons-lang3-api-plugin/job/main/)
-[![Contributors](https://img.shields.io/github/contributors/jenkinsci/commons-lang3-api-plugin.svg)](https://github.com/jenkinsci/commons-lang3-api-plugin/graphs/contributors)
-[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/commons-lang3-api-plugin.svg)](https://plugins.jenkins.io/commons-lang3-api)
-[![GitHub release](https://img.shields.io/github/v/tag/jenkinsci/commons-lang3-api-plugin?label=changelog)](https://github.com/jenkinsci/commons-lang3-api-plugin/blob/main/CHANGELOG.md)
-[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/commons-lang3-api-plugin.svg?color=blue)](https://plugins.jenkins.io/commons-lang3-api)
-
 This plugin provides [Commons Lang v3.x](https://commons.apache.org/proper/commons-lang/) to Jenkins Plugins.<br>
 
 Version will be "&lt;commons-lang version&gt;_&lt;plugin version&gt;", so clear what upstream dependency it is offering and plugin can be patch by "plugin version" if required.
@@ -36,13 +30,15 @@ Replace the dependency to `org.apache.commons:commons-lang3` with the dependency
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>commons-lang3-api</artifactId>
-        <version>3.12.0_0</version>
+        <version>3.12.0-…</version>
       </dependency>
       ...
     </dependencies>
     ```
 
-### Change Log
+### Historical change log
+
+For current versions, see [GitHub Releases](https://github.com/jenkinsci/commons-lang3-api-plugin/releases).
 
 #### Version 3.12.0_0 (Feb TBC, 2022)
 - First release

--- a/pom.xml
+++ b/pom.xml
@@ -4,33 +4,26 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.42</version>
+        <version>4.43.1</version>
+        <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>commons-lang3-api</artifactId>
-    <version>3.12.0.1-SNAPSHOT</version>
+    <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <revision>3.12.0</revision>
+        <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.289.1</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
-    <name>commons-lang3 v3.x Jenkins Api Plugin</name>
-    <description>Jenkins Api Plugin to provide org.apache.commons:commons-lang3:${commons-lang3.version}.
-        Will break usage upon jars being provided by core jenkins.</description>
-    <url>https://github.com/jenkinsci/commons-lang3-api-plugin</url>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <name>commons-lang3 v3.x Jenkins API Plugin</name>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
     <build>
@@ -47,10 +40,11 @@
             <url>https://opensource.org/licenses/Apache-2.0</url>
         </license>
     </licenses>
-    <scm>
-        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+        <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+        <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
+        <tag>${scmTag}</tag>
+        <url>https://github.com/${gitHubRepo}</url>
     </scm>
     <repositories>
         <repository>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -4,5 +4,5 @@
   <br/>
   Usage will slim downstream plugin and not require dependency jar being provided by core Jenkins.
   <br/>
-  Provides org.apache.commons:commons-lang3:${commons-lang3.version}.
+  Provides org.apache.commons:commons-lang3:${revision}.
 </div>


### PR DESCRIPTION
Fixes #18. Fixes #12.

https://www.jenkins.io/doc/developer/publishing/releasing-cd/

Presumes https://github.com/jenkins-infra/repository-permissions-updater/pull/2659 has been merged and a secret created.

Supersedes or subsumes #19 & #6 & #17.

@timja
